### PR TITLE
Fixed rx_name warning; set the values for vars in the rfc py test

### DIFF
--- a/cloud/ixia-c-dpdk-azure-boost-eth2/configs/throughput_rfc2544_n_flows.json
+++ b/cloud/ixia-c-dpdk-azure-boost-eth2/configs/throughput_rfc2544_n_flows.json
@@ -36,7 +36,7 @@
                 "choice": "port",
                 "port": {
                     "tx_name": "VM1-TE1",
-                    "rx_name": "VM2-TE1"
+                    "rx_names": ["VM2-TE1"]
                 }
             },
             "metrics": {
@@ -104,7 +104,7 @@
                 "choice": "port",
                 "port": {
                     "tx_name": "VM1-TE2",
-                    "rx_name": "VM2-TE2"
+                    "rx_names": ["VM2-TE2"]
                 }
             },
             "metrics": {

--- a/cloud/ixia-c-dpdk-azure-boost-eth2/py/test_throughput_rfc2544_n_flows.py
+++ b/cloud/ixia-c-dpdk-azure-boost-eth2/py/test_throughput_rfc2544_n_flows.py
@@ -3,14 +3,14 @@ import pytest
 import time
 import json
 
-THEORETICAL_MAX_LINK_SPEED = 10    #  Gbps
+THEORETICAL_MAX_LINK_SPEED = 100    #  Gbps
 PACKET_LOSS_TOLERANCE      = 1.0   # percent
 NO_DETERMINATION_STEPS     = 10
 NO_VALIDATION_STEPS        = 5
 TRIAL_RUN_TIME             = 5  # seconds
 FINAL_RUN_TIME             = 30 # seconds
 TEST_GAP_TIME              = 1  # seconds
-VALIDATION_DECREASE_LINE_PERCENTAGE = 0.01
+VALIDATION_DECREASE_LINE_PERCENTAGE = 2
 RESULTS_FILE_PATH          = "./throughput_results_rfc2544_n_flows.json"
 
 

--- a/cloud/ixia-c-dpdk-azure-boost/configs/throughput_rfc2544_n_flows.json
+++ b/cloud/ixia-c-dpdk-azure-boost/configs/throughput_rfc2544_n_flows.json
@@ -26,7 +26,7 @@
                 "choice": "port",
                 "port": {
                     "tx_name": "VM1-TE1",
-                    "rx_name": "VM2-TE1"
+                    "rx_names": ["VM2-TE1"]
                 }
             },
             "metrics": {

--- a/cloud/ixia-c-dpdk-azure-boost/py/test_throughput_rfc2544_n_flows.py
+++ b/cloud/ixia-c-dpdk-azure-boost/py/test_throughput_rfc2544_n_flows.py
@@ -3,14 +3,14 @@ import pytest
 import time
 import json
 
-THEORETICAL_MAX_LINK_SPEED = 10    #  Gbps
+THEORETICAL_MAX_LINK_SPEED = 100    #  Gbps
 PACKET_LOSS_TOLERANCE      = 1.0   # percent
 NO_DETERMINATION_STEPS     = 10
 NO_VALIDATION_STEPS        = 5
 TRIAL_RUN_TIME             = 5  # seconds
 FINAL_RUN_TIME             = 30 # seconds
 TEST_GAP_TIME              = 1  # seconds
-VALIDATION_DECREASE_LINE_PERCENTAGE = 0.01
+VALIDATION_DECREASE_LINE_PERCENTAGE = 2
 RESULTS_FILE_PATH          = "./throughput_results_rfc2544_n_flows.json"
 
 


### PR DESCRIPTION
We should use: `"rx_names": ["VM2-TE1"]`  to avoid rx_name warnings. 
We should use an integer value between 1 and 100 for the  VALIDATION_DECREASE_LINE_PERCENTAGE. 

I recommend 2 or 3 or 4.